### PR TITLE
fix(telemetry): Restore dual-write logging to the Systemd journal

### DIFF
--- a/core/mod_google.sh
+++ b/core/mod_google.sh
@@ -22,9 +22,20 @@ if ! type log >/dev/null 2>&1; then
         # [v3.4.0 核心] 提取当前配置中的版本锚点
         local local_ver="${AGENT_VERSION:-未知}"
         
+        # 保证日志目录存在
         mkdir -p "${INSTALL_DIR}/logs"
-        # 统一日志格式，注入 [版本号] 追踪标识
-        printf "[$(date '+%Y-%m-%d %H:%M:%S')] [v%-5s] [%-5s] [%-7s] [%s] %s\n" "$local_ver" "$2" "$1" "$REGION_CODE" "$3" >> "${INSTALL_DIR}/logs/sentinel.log"
+    
+        # 日志格式注入 [版本号] 追踪标识
+        local core_msg=$(printf "[v%-5s] [%-5s] [%-7s] [%s] %s" "$local_ver" "$2" "$1" "$REGION_CODE" "$3")
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] $core_msg" >> "${INSTALL_DIR}/logs/sentinel.log"
+
+        # 强制推送到 Systemd Journal (如果系统支持)
+        if command -v logger >/dev/null 2>&1; then
+            logger -t ip-sentinel "$core_msg"
+        else
+            # 降级输出到 stdout，让 Systemd 捕获
+            echo "$core_msg"
+        fi
     }
 fi
 

--- a/core/runner.sh
+++ b/core/runner.sh
@@ -33,8 +33,18 @@ log() {
     
     # 保证日志目录存在
     mkdir -p "${INSTALL_DIR}/logs"
+    
     # 日志格式注入 [版本号] 追踪标识
-    printf "[$(date '+%Y-%m-%d %H:%M:%S')] [v%-5s] [%-5s] [%-7s] [%s] %s\n" "$local_ver" "$level" "$module" "$REGION_CODE" "$msg" >> "$LOG_FILE"
+    local core_msg=$(printf "[v%-5s] [%-5s] [%-7s] [%s] %s" "$local_ver" "$level" "$module" "$REGION_CODE" "$msg")
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $core_msg" >> "$LOG_FILE"
+
+    # 强制推送到 Systemd Journal (如果系统支持)
+    if command -v logger >/dev/null 2>&1; then
+        logger -t ip-sentinel "$core_msg"
+    else
+        # 降级输出到 stdout，让 Systemd 捕获
+        echo "$core_msg"
+    fi
 }
 export -f log
 export CONFIG_FILE INSTALL_DIR

--- a/core/updater.sh
+++ b/core/updater.sh
@@ -25,9 +25,20 @@ log() {
     # [v3.4.0 核心] 提取当前配置中的版本锚点
     local local_ver="${AGENT_VERSION:-未知}"
     
+    # 保证日志目录存在
     mkdir -p "${INSTALL_DIR}/logs"
+
     # 日志格式注入 [版本号] 追踪标识
-    printf "[$(date '+%Y-%m-%d %H:%M:%S')] [v%-5s] [%-5s] [%-7s] [%s] %s\n" "$local_ver" "$2" "$1" "$REGION_CODE" "$3" >> "$LOG_FILE"
+    local core_msg=$(printf "[v%-5s] [%-5s] [%-7s] [%s] %s" "$local_ver" "$2" "$1" "$REGION_CODE" "$3")
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $core_msg" >> "$LOG_FILE"
+
+    # 强制推送到 Systemd Journal (如果系统支持)
+    if command -v logger >/dev/null 2>&1; then
+        logger -t ip-sentinel "$core_msg"
+    else
+        # 降级输出到 stdout，让 Systemd 捕获
+        echo "$core_msg"
+    fi
 }
 
 log "Updater" "INFO " "========== 触发后台静默 OTA 热数据更新 =========="


### PR DESCRIPTION
Reapply commit `e77b7c0`, which was (inadvertently?) omitted in the recent upstream rollup `34320b2`.

Original commit description:
```
This commit refactors the internal logging functions across all core modules to guarantee telemetry reaches the Systemd journal. Sentinels now mirror their physical log outputs directly to the OS `logger`, ensuring flawless `journalctl` visibility even when modules are spawned in detached subshells.
```