### PR TITLE
Change pacman install to use --needed flag

### DIFF
--- a/core/install.sh
+++ b/core/install.sh
@@ -85,7 +85,7 @@ if [ ${#MISSING_CMDS[@]} -gt 0 ]; then
         
     elif command -v pacman >/dev/null 2>&1; then
         # Arch Linux 系列
-        pacman -Sy --noconfirm curl jq cronie procps-ng python openssl >/dev/null 2>&1
+        pacman -Sy --needed --noconfirm curl jq cronie procps-ng python openssl >/dev/null 2>&1
         mkdir -p /root/.cache/crontab 2>/dev/null
         systemctl enable cronie >/dev/null 2>&1 && systemctl start cronie >/dev/null 2>&1
         

--- a/core/install.sh
+++ b/core/install.sh
@@ -85,7 +85,7 @@ if [ ${#MISSING_CMDS[@]} -gt 0 ]; then
         
     elif command -v pacman >/dev/null 2>&1; then
         # Arch Linux 系列
-        pacman -Sy --needed --noconfirm curl jq cronie procps-ng python openssl >/dev/null 2>&1
+        pacman -S --needed --noconfirm curl jq cronie procps-ng python openssl >/dev/null 2>&1
         mkdir -p /root/.cache/crontab 2>/dev/null
         systemctl enable cronie >/dev/null 2>&1 && systemctl start cronie >/dev/null 2>&1
         


### PR DESCRIPTION
1. 使用`--needed`避免重复安装已安装的包。
2. 改用`-S`参数。不要使用`-Sy`参数安装软件包，`-Sy`安装软件包属于部分更新。这种行为是不受Arch Linux官方支持的，甚至有可能会损坏系统，导致系统无法正常启动。