### PR TITLE
feat(data): add Hawaii Honolulu region

### DIFF
--- a/data/map.json
+++ b/data/map.json
@@ -276,6 +276,16 @@
               ]
             },
             {
+              "id": "HI",
+              "name": "Hawaii (夏威夷州)",
+              "cities": [
+                {
+                  "id": "Honolulu",
+                  "name": "Honolulu (檀香山)"
+                }
+              ]
+            },
+            {
               "id": "IL",
               "name": "Illinois (伊利诺伊州)",
               "cities": [

--- a/data/regions/US/HI/Honolulu.json
+++ b/data/regions/US/HI/Honolulu.json
@@ -1,0 +1,45 @@
+{
+  "region_name": "United States - Hawaii (Honolulu)",
+  "google_module": {
+    "base_lat": 21.3069,
+    "base_lon": -157.8583,
+    "lang_params": "hl=en-US&gl=US",
+    "valid_url_suffix": "com"
+  },
+  "trust_module": {
+    "white_urls": [
+      "https://www.hawaii.edu/",
+      "https://www.thebus.org/",
+      "https://www.honolulutransit.org/",
+      "https://www.hawaiitourismauthority.org/",
+      "https://www.staradvertiser.com/",
+      "https://www.hawaiinewsnow.com/",
+      "https://www.kitv.com/",
+      "https://www.oneoahu.org/",
+      "https://www.civilbeat.org/",
+      "https://www.hawaiipublicradio.org/",
+      "https://www.pbshawaii.org/",
+      "https://www.hawaiianelectric.com/",
+      "https://www.hmsa.com/",
+      "https://www.queens.org/",
+      "https://www.hawaiipacifichealth.org/",
+      "https://www.boh.com/",
+      "https://www.fhb.com/",
+      "https://www.asbhawaii.com/",
+      "https://www.chaminade.edu/",
+      "https://www.hpu.edu/"
+    ],
+    "static_urls": [
+      "https://www.hawaii.edu/",
+      "https://www.thebus.org/",
+      "https://www.oneoahu.org/",
+      "https://www.hawaiitourismauthority.org/",
+      "https://www.staradvertiser.com/",
+      "https://www.hawaiinewsnow.com/",
+      "https://www.hawaiianelectric.com/",
+      "https://www.boh.com/",
+      "https://www.fhb.com/",
+      "https://www.asbhawaii.com/"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Add Hawaii (HI) / Honolulu to the US region map.
- Add Honolulu region rules with US Google locale settings and Honolulu coordinates.
- Populate Trust module URLs with verified Hawaii/Honolulu-relevant institutions, local media, banks, utilities, transit, healthcare, and education sites.

## Validation
- jq parsed both data/map.json and data/regions/US/HI/Honolulu.json successfully.
- Verified the map entry resolves to data/regions/US/HI/Honolulu.json with the existing install path convention.
- Verified all Honolulu white_urls with the same curl style used by mod_trust.sh returned accepted 20x/30x responses.
- Ran python3 -m py_compile for scripts/fetch_trust_urls.py, scripts/fetch_trends.py, and scripts/ua_generator.py.

## Notes
- Hawaii .gov candidates were intentionally excluded from runtime white_urls because they failed TLS handshakes from the validation environment.
- No new kw_HI.txt is needed; the existing architecture keeps US keywords at kw_US.txt.